### PR TITLE
Supress warning as error for `unused-function`

### DIFF
--- a/agent/Makefile.am
+++ b/agent/Makefile.am
@@ -13,6 +13,7 @@ AM_CFLAGS = \
 	$(LIBNICE_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(GUPNP_CFLAGS) \
+	-Wno-error=unused-function \
 	-I $(top_srcdir) \
 	-I $(top_srcdir)/random \
 	-I $(top_srcdir)/socket \


### PR DESCRIPTION
The `inet_pton_...` polyfill function is not currently being used, so
either remove the function or suppress the warning. I opted for the
latter since it's a function that should arguably already have been
there to begin with.