### PR TITLE
Use G_GSIZE_FORMAT instead of %zu

### DIFF
--- a/agent/conncheck.c
+++ b/agent/conncheck.c
@@ -2957,7 +2957,7 @@ static bool conncheck_stun_validater (StunAgent *agent,
     if (ufrag == NULL)
       continue;
 
-    stun_debug ("Comparing username/ufrag of len %d and %zu, equal=%d",
+    stun_debug ("Comparing username/ufrag of len %d and %" G_GSIZE_FORMAT ", equal=%d",
         username_len, ufrag_len, username_len >= ufrag_len ?
         memcmp (username, ufrag, ufrag_len) : 0);
     stun_debug_bytes ("  username: ", username, username_len);


### PR DESCRIPTION
The C runtime on windows does not implement a printf that understands
`%zu` and other C99 format specifiers. Use `G_GSIZE_FORMAT` instead. This
is further consistent with the rest of the code base that makes use of
`G_GSIZE_FORMAT` throughout.