### PR TITLE
Fix T121 - Libnice not picking up UDP packets

### DIFF
--- a/socket/udp-bsd.c
+++ b/socket/udp-bsd.c
@@ -53,6 +53,10 @@
 
 #ifndef G_OS_WIN32
 #include <unistd.h>
+#else
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR,12)
 #endif
 
 
@@ -86,6 +90,11 @@ nice_udp_bsd_socket_new (NiceAddress *addr)
   gboolean gret = FALSE;
   GSocketAddress *gaddr;
   struct UdpBsdSocketPrivate *priv;
+
+#ifdef G_OS_WIN32
+  DWORD winsock_bytes_returned = 0;
+  BOOL  winsock_use_new_behvaiour = FALSE;
+#endif
 
   if (addr != NULL) {
     nice_address_copy_to_sockaddr(addr, &name.addr);
@@ -155,6 +164,12 @@ nice_udp_bsd_socket_new (NiceAddress *addr)
   sock->can_send = socket_can_send;
   sock->set_writable_callback = socket_set_writable_callback;
   sock->close = socket_close;
+
+#ifdef G_OS_WIN32
+  WSAIoctl(g_socket_get_fd(gsock), SIO_UDP_CONNRESET,
+          &winsock_use_new_behvaiour, sizeof(winsock_use_new_behvaiour),
+          NULL, 0, &winsock_bytes_returned, NULL, NULL);
+#endif
 
   return sock;
 }


### PR DESCRIPTION
Fix [T121][report] - Libnice not picking up UDP packets

Set winsock options to get around a [known bug in windows][bug].
Without this patch, UDP sockets may falsely return a `WSAECONNRESET`
when trying to read data. Once libnice receives a `WSAECONNRESET` on
a socket, it detaches the source and cleans up, as it should, so these
false positives (the socket is still there and can receive data) cause
libnice to ditch perfectly good connections.

[bug]: https://support.microsoft.com/en-us/kb/263823
[report]: http://phabricator.freedesktop.org/T121