### PR TITLE
Fix TCP-passive connectivity

### DIFF
--- a/agent/conncheck.c
+++ b/agent/conncheck.c
@@ -3181,7 +3181,6 @@ gboolean conn_check_handle_inbound_stun (NiceAgent *agent, NiceStream *stream,
   }
 
   if (local_candidate != NULL && local_candidate->transport == NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE) {
-    g_assert (local_candidate->sockptr == NULL);
     local_candidate->sockptr = nicesock;
   }
 

--- a/agent/conncheck.c
+++ b/agent/conncheck.c
@@ -3180,6 +3180,11 @@ gboolean conn_check_handle_inbound_stun (NiceAgent *agent, NiceStream *stream,
     }
   }
 
+  if (local_candidate != NULL && local_candidate->transport == NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE) {
+        local_candidate->sockptr = nicesock;
+  }
+
+
   if (agent->compatibility == NICE_COMPATIBILITY_GOOGLE ||
       agent->compatibility == NICE_COMPATIBILITY_MSN ||
       agent->compatibility == NICE_COMPATIBILITY_OC2007) {

--- a/agent/conncheck.c
+++ b/agent/conncheck.c
@@ -3181,7 +3181,8 @@ gboolean conn_check_handle_inbound_stun (NiceAgent *agent, NiceStream *stream,
   }
 
   if (local_candidate != NULL && local_candidate->transport == NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE) {
-        local_candidate->sockptr = nicesock;
+    g_assert (local_candidate->sockptr == NULL);
+    local_candidate->sockptr = nicesock;
   }
 
 


### PR DESCRIPTION
Fixed TCP-passive host candidate connectivity check(Updating local candidate socket after accepting connection). The problem is that libnice tries to use listening socket for connectivity insted of using socket created after accepting the connection
This has not been tested against latest master but it has been testes against some 0.1.13 build
