### PR TITLE
configure.ac: Update glib version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,9 +93,9 @@ AC_CHECK_HEADERS([ifaddrs.h], \
 AC_CHECK_TYPES([size_t, ssize_t])
 
 # Also put matching version in LIBNICE_CFLAGS
-GLIB_REQ=2.36
+GLIB_REQ=2.44
 
-LIBNICE_CFLAGS="-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_36 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_36"
+LIBNICE_CFLAGS="-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_44 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_44"
 
 dnl Support different levels of compiler error reporting.
 dnl This configure flag is designed to mimic one from gnome-common,


### PR DESCRIPTION
As udp-bsd.c code is using G_IO_ERROR_CONNECTION_CLOSED glib 2.44
is required.

Also added a task in phabricator: https://phabricator.freedesktop.org/T3492