### PR TITLE
agent: don't give up gathering when can't create socket for an IP

### DIFF
--- a/agent/agent.c
+++ b/agent/agent.c
@@ -2783,8 +2783,7 @@ nice_agent_gather_candidates (
                 " s%d:%d. Invalid interface?", agent, ip, stream->id,
                 component->id);
           }
-          ret = FALSE;
-          goto error;
+          continue;
         }
 
         nice_address_set_port (addr, 0);


### PR DESCRIPTION
Candidate gathering is stopped when discovery_add_local_host_candidate()
returns HOST_CANDIDATE_CANT_CREATE_SOCKET. This may be too radical
a measure when other local addresses can still be able to generate
usable candidates.

The issue was observed by a user who had an IPv6 address with tentative
flag on one of the interfaces. That single failing address was causing
the whole gathering process to end with no candidates found.