### PR TITLE
Lock contention removed.

### DIFF
--- a/agent/agent-priv.h
+++ b/agent/agent-priv.h
@@ -118,6 +118,10 @@ struct _NiceAgent
 {
   GObject parent;                 /* gobject pointer */
 
+  gint agent_mutex_count;
+  GThread *agent_mutex_th;
+  GRecMutex agent_mutex;          /* Mutex used for thread-safe lib */
+
   gboolean full_mode;             /* property: full-mode */
   gchar *stun_server_ip;          /* property: STUN server IP */
   guint stun_server_port;         /* property: STUN server port */
@@ -180,8 +184,8 @@ NiceStream *agent_find_stream (NiceAgent *agent, guint stream_id);
 void agent_gathering_done (NiceAgent *agent);
 void agent_signal_gathering_done (NiceAgent *agent);
 
-void agent_lock (void);
-void agent_unlock (void);
+void agent_lock (NiceAgent *agent);
+void agent_unlock (NiceAgent *agent);
 void agent_unlock_and_emit (NiceAgent *agent);
 
 void agent_signal_new_selected_pair (

--- a/agent/agent.c
+++ b/agent/agent.c
@@ -135,8 +135,6 @@ enum
 
 static guint signals[N_SIGNALS];
 
-static GMutex agent_mutex;    /* Mutex used for thread-safe lib */
-
 static void priv_stop_upnp (NiceAgent *agent);
 
 static void pseudo_tcp_socket_opened (PseudoTcpSocket *sock, gpointer user_data);
@@ -154,14 +152,24 @@ static void nice_agent_get_property (GObject *object,
 static void nice_agent_set_property (GObject *object,
   guint property_id, const GValue *value, GParamSpec *pspec);
 
-void agent_lock (void)
+void agent_lock (NiceAgent *agent)
 {
-  g_mutex_lock (&agent_mutex);
+  g_rec_mutex_lock (&agent->agent_mutex);
+  g_assert (agent->agent_mutex_count >= 0);
+
+  if (agent->agent_mutex_count == 0)
+    agent->agent_mutex_th = g_thread_self();
+  ++agent->agent_mutex_count;
 }
 
-void agent_unlock (void)
+void agent_unlock (NiceAgent *agent)
 {
-  g_mutex_unlock (&agent_mutex);
+  --agent->agent_mutex_count;
+  if (agent->agent_mutex_count == 0)
+    agent->agent_mutex_th = NULL;
+
+  g_assert (agent->agent_mutex_count >= 0);
+  g_rec_mutex_unlock (&agent->agent_mutex);
 }
 
 static GType _nice_agent_stream_ids_get_type (void);
@@ -203,7 +211,7 @@ agent_unlock_and_emit (NiceAgent *agent)
   queue = agent->pending_signals;
   g_queue_init (&agent->pending_signals);
 
-  agent_unlock ();
+  agent_unlock (agent);
 
   while ((sig = g_queue_pop_head (&queue))) {
     g_signal_emitv (sig->params, sig->signal_id, 0, NULL);
@@ -1042,6 +1050,8 @@ nice_agent_init (NiceAgent *agent)
   priv_generate_tie_breaker (agent);
 
   g_queue_init (&agent->pending_signals);
+
+  g_rec_mutex_init (&agent->agent_mutex);
 }
 
 
@@ -1080,7 +1090,7 @@ nice_agent_get_property (
 {
   NiceAgent *agent = NICE_AGENT (object);
 
-  agent_lock();
+  agent_lock (agent);
 
   switch (property_id)
     {
@@ -1264,7 +1274,7 @@ nice_agent_set_property (
 {
   NiceAgent *agent = NICE_AGENT (object);
 
-  agent_lock();
+  agent_lock (agent);
 
   switch (property_id)
     {
@@ -1791,15 +1801,15 @@ notify_pseudo_tcp_socket_clock (gpointer user_data)
   NiceStream *stream;
   NiceAgent *agent;
 
-  agent_lock();
-
   stream = component->stream;
   agent = component->agent;
+
+  agent_lock (agent);
 
   if (g_source_is_destroyed (g_main_current_source ())) {
     nice_debug ("Source was destroyed. "
         "Avoided race condition in notify_pseudo_tcp_socket_clock");
-    agent_unlock ();
+    agent_unlock (agent);
     return FALSE;
   }
 
@@ -1850,13 +1860,13 @@ _tcp_sock_is_writable (NiceSocket *sock, gpointer user_data)
   NiceAgent *agent = component->agent;
   NiceStream *stream = component->stream;
 
-  agent_lock ();
+  agent_lock (agent);
 
   /* Don't signal writable if the socket that has become writable is not
    * the selected pair */
   if (component->selected_pair.local == NULL ||
       !nice_socket_is_based_on (component->selected_pair.local->sockptr, sock)) {
-    agent_unlock ();
+    agent_unlock (agent);
     return;
   }
 
@@ -2314,7 +2324,7 @@ priv_add_new_candidate_discovery_turn (NiceAgent *agent,
         agent->proxy_ip != NULL &&
         nice_address_set_from_string (&proxy_server, agent->proxy_ip)) {
       nice_address_set_port (&proxy_server, agent->proxy_port);
-      nicesock = nice_tcp_bsd_socket_new (agent->main_context, &local_address,
+      nicesock = nice_tcp_bsd_socket_new (agent, agent->main_context, &local_address,
           &proxy_server, reliable_tcp);
 
       if (nicesock) {
@@ -2333,7 +2343,7 @@ priv_add_new_candidate_discovery_turn (NiceAgent *agent,
 
     }
     if (nicesock == NULL) {
-      nicesock = nice_tcp_bsd_socket_new (agent->main_context, &local_address,
+      nicesock = nice_tcp_bsd_socket_new (agent, agent->main_context, &local_address,
           &turn->server, reliable_tcp);
 
       if (nicesock)
@@ -2412,7 +2422,7 @@ nice_agent_add_stream (
   g_return_val_if_fail (NICE_IS_AGENT (agent), 0);
   g_return_val_if_fail (n_components >= 1, 0);
 
-  agent_lock();
+  agent_lock (agent);
   stream = nice_stream_new (n_components, agent);
 
   agent->streams = g_slist_append (agent->streams, stream);
@@ -2461,7 +2471,7 @@ nice_agent_set_relay_info(NiceAgent *agent,
   g_return_val_if_fail (password, FALSE);
   g_return_val_if_fail (type <= NICE_RELAY_TYPE_TURN_TLS, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id, &stream,
           &component)) {
@@ -2518,11 +2528,11 @@ static gboolean priv_upnp_timeout_cb (gpointer user_data)
 {
   NiceAgent *agent = (NiceAgent*)user_data;
 
-  agent_lock();
+  agent_lock (agent);
 
   /* If the source has been destroyed, we have already freed all mappings. */
   if (g_source_is_destroyed (g_main_current_source ())) {
-    agent_unlock ();
+    agent_unlock (agent);
     return FALSE;
   }
 
@@ -2570,7 +2580,7 @@ static void _upnp_mapped_external_port (GUPnPSimpleIgd *self, gchar *proto,
   NiceCandidateTransport transport;
   GSList *i, *j, *k;
 
-  agent_lock();
+  agent_lock (agent);
 
   if (agent->upnp_timer_source == NULL)
     goto end;
@@ -2640,7 +2650,7 @@ static void _upnp_error_mapping_port (GUPnPSimpleIgd *self, GError *error,
   NiceAddress localaddr;
   GSList *i;
 
-  agent_lock();
+  agent_lock (agent);
 
   nice_debug ("Agent %p : Error mapping %s:%d to %d (%d) : %s", agent, local_ip,
       local_port, external_port, error->domain, error->message);
@@ -2678,7 +2688,7 @@ nice_agent_gather_candidates (
   g_return_val_if_fail (NICE_IS_AGENT (agent), FALSE);
   g_return_val_if_fail (stream_id >= 1, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (stream == NULL) {
@@ -3015,7 +3025,7 @@ nice_agent_remove_stream (
   g_return_if_fail (NICE_IS_AGENT (agent));
   g_return_if_fail (stream_id >= 1);
 
-  agent_lock();
+  agent_lock (agent);
   stream = agent_find_stream (agent, stream_id);
 
   if (!stream) {
@@ -3059,7 +3069,7 @@ nice_agent_set_port_range (NiceAgent *agent, guint stream_id, guint component_id
   g_return_if_fail (stream_id >= 1);
   g_return_if_fail (component_id >= 1);
 
-  agent_lock();
+  agent_lock (agent);
 
   if (agent_find_component (agent, stream_id, component_id, &stream,
           &component)) {
@@ -3082,7 +3092,7 @@ nice_agent_add_local_address (NiceAgent *agent, NiceAddress *addr)
   g_return_val_if_fail (NICE_IS_AGENT (agent), FALSE);
   g_return_val_if_fail (addr != NULL, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   dupaddr = nice_address_dup (addr);
   nice_address_set_port (dupaddr, 0);
@@ -3226,7 +3236,7 @@ nice_agent_set_remote_credentials (
   g_return_val_if_fail (NICE_IS_AGENT (agent), FALSE);
   g_return_val_if_fail (stream_id >= 1, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   /* note: oddly enough, ufrag and pwd can be empty strings */
@@ -3257,7 +3267,7 @@ nice_agent_set_local_credentials (
   g_return_val_if_fail (NICE_IS_AGENT (agent), FALSE);
   g_return_val_if_fail (stream_id >= 1, FALSE);
 
-  agent_lock ();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
 
@@ -3288,7 +3298,7 @@ nice_agent_get_local_credentials (
   g_return_val_if_fail (NICE_IS_AGENT (agent), FALSE);
   g_return_val_if_fail (stream_id >= 1, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (stream == NULL) {
@@ -3360,7 +3370,7 @@ nice_agent_set_remote_candidates (NiceAgent *agent, guint stream_id, guint compo
 
   nice_debug ("Agent %p: set_remote_candidates %d %d", agent, stream_id, component_id);
 
-  agent_lock();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id,
           &stream, &component)) {
@@ -4134,7 +4144,7 @@ nice_agent_recv_messages_blocking_or_nonblocking (NiceAgent *agent,
     }
   }
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id,
           &stream, &component)) {
@@ -4227,9 +4237,9 @@ nice_agent_recv_messages_blocking_or_nonblocking (NiceAgent *agent,
     memcpy (&prev_recv_messages_iter, &component->recv_messages_iter,
         sizeof (NiceInputMessageIter));
 
-    agent_unlock ();
+    agent_unlock (agent);
     g_main_context_iteration (context, blocking);
-    agent_lock ();
+    agent_lock (agent);
 
     if (!agent_find_component (agent, stream_id, component_id,
             &stream, &component)) {
@@ -4421,7 +4431,7 @@ nice_agent_send_messages_nonblocking_internal (
 
   g_assert (n_messages == 1 || !allow_partial);
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id,
           &stream, &component)) {
@@ -4668,7 +4678,7 @@ nice_agent_get_local_candidates (
   g_return_val_if_fail (stream_id >= 1, NULL);
   g_return_val_if_fail (component_id >= 1, NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id, NULL, &component)) {
     goto done;
@@ -4702,7 +4712,7 @@ nice_agent_get_remote_candidates (
   g_return_val_if_fail (stream_id >= 1, NULL);
   g_return_val_if_fail (component_id >= 1, NULL);
 
-  agent_lock();
+  agent_lock (agent);
   if (!agent_find_component (agent, stream_id, component_id, NULL, &component))
     {
       goto done;
@@ -4722,7 +4732,7 @@ nice_agent_restart (
 {
   GSList *i;
 
-  agent_lock();
+  agent_lock (agent);
 
   /* step: regenerate tie-breaker value */
   priv_generate_tie_breaker (agent);
@@ -4747,7 +4757,7 @@ nice_agent_restart_stream (
   gboolean res = FALSE;
   NiceStream *stream;
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (!stream) {
@@ -4772,6 +4782,8 @@ nice_agent_dispose (GObject *object)
   GSList *i;
   QueuedSignal *sig;
   NiceAgent *agent = NICE_AGENT (object);
+
+  agent_lock (agent);
 
   /* step: free resources for the binding discovery timers */
   discovery_free (agent);
@@ -4838,6 +4850,11 @@ nice_agent_dispose (GObject *object)
     g_main_context_unref (agent->main_context);
   agent->main_context = NULL;
 
+  agent_unlock (agent);
+
+  g_assert (agent->agent_mutex_th == NULL);
+  g_rec_mutex_clear (&agent->agent_mutex);
+
   if (G_OBJECT_CLASS (nice_agent_parent_class)->dispose)
     G_OBJECT_CLASS (nice_agent_parent_class)->dispose (object);
 
@@ -4853,19 +4870,20 @@ component_io_cb (GSocket *gsocket, GIOCondition condition, gpointer user_data)
   gboolean has_io_callback;
   gboolean remove_source = FALSE;
 
-  agent_lock ();
+  component = socket_source->component;
+  agent = component->agent;
+  stream = component->stream;
+
+  agent_lock (agent);
 
   if (g_source_is_destroyed (g_main_current_source ())) {
     /* Silently return FALSE. */
     nice_debug ("%s: source %p destroyed", G_STRFUNC, g_main_current_source ());
 
-    agent_unlock ();
+    agent_unlock (agent);
     return G_SOURCE_REMOVE;
   }
 
-  component = socket_source->component;
-  agent = component->agent;
-  stream = component->stream;
 
   g_object_ref (agent);
 
@@ -4883,7 +4901,7 @@ component_io_cb (GSocket *gsocket, GIOCondition condition, gpointer user_data)
     }
 
     nice_component_remove_socket (component, socket_source->socket);
-    agent_unlock ();
+    agent_unlock (agent);
     g_object_unref (agent);
     return G_SOURCE_REMOVE;
   }
@@ -5051,7 +5069,7 @@ done:
   if (component->n_recv_messages == 0 && component->recv_messages == NULL) {
     agent_unlock_and_emit (agent);
   } else {
-    agent_unlock ();
+    agent_unlock (agent);
   }
 
   g_object_unref (agent);
@@ -5082,7 +5100,7 @@ nice_agent_attach_recv (
   g_return_val_if_fail (stream_id >= 1, FALSE);
   g_return_val_if_fail (component_id >= 1, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   /* attach candidates */
 
@@ -5137,7 +5155,7 @@ nice_agent_set_selected_pair (
   g_return_val_if_fail (lfoundation, FALSE);
   g_return_val_if_fail (rfoundation, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   /* step: check that params specify an existing pair */
   if (!agent_find_component (agent, stream_id, component_id, &stream, &component)) {
@@ -5199,7 +5217,7 @@ nice_agent_get_selected_pair (NiceAgent *agent, guint stream_id,
   g_return_val_if_fail (local != NULL, FALSE);
   g_return_val_if_fail (remote != NULL, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   /* step: check that params specify an existing pair */
   if (!agent_find_component (agent, stream_id, component_id,
@@ -5231,7 +5249,7 @@ nice_agent_get_selected_socket (NiceAgent *agent, guint stream_id,
   g_return_val_if_fail (stream_id >= 1, NULL);
   g_return_val_if_fail (component_id >= 1, NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   /* Reliable streams are pseudotcp or MUST use RFC 4571 framing */
   if (agent->reliable)
@@ -5314,7 +5332,7 @@ nice_agent_set_selected_remote_candidate (
   g_return_val_if_fail (component_id != 0, FALSE);
   g_return_val_if_fail (candidate != NULL, FALSE);
 
-  agent_lock();
+  agent_lock (agent);
 
   /* step: check if the component exists*/
   if (!agent_find_component (agent, stream_id, component_id, &stream, &component)) {
@@ -5403,7 +5421,7 @@ nice_agent_set_stream_tos (NiceAgent *agent,
   g_return_if_fail (NICE_IS_AGENT (agent));
   g_return_if_fail (stream_id >= 1);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (stream == NULL)
@@ -5429,7 +5447,7 @@ nice_agent_set_software (NiceAgent *agent, const gchar *software)
 {
   g_return_if_fail (NICE_IS_AGENT (agent));
 
-  agent_lock();
+  agent_lock (agent);
 
   g_free (agent->software_attribute);
   if (software)
@@ -5464,7 +5482,7 @@ nice_agent_set_stream_name (NiceAgent *agent, guint stream_id,
         " are valid", name);
   }
 
-  agent_lock();
+  agent_lock (agent);
 
   for (i = agent->streams; i; i = i->next) {
     NiceStream *stream = i->data;
@@ -5499,7 +5517,7 @@ nice_agent_get_stream_name (NiceAgent *agent, guint stream_id)
   g_return_val_if_fail (NICE_IS_AGENT (agent), NULL);
   g_return_val_if_fail (stream_id >= 1, NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (stream == NULL)
@@ -5573,7 +5591,7 @@ nice_agent_get_default_local_candidate (NiceAgent *agent,
   g_return_val_if_fail (stream_id >= 1, NULL);
   g_return_val_if_fail (component_id >= 1, NULL);
 
-  agent_lock ();
+  agent_lock (agent);
 
   /* step: check if the component exists*/
   if (!agent_find_component (agent, stream_id, component_id,
@@ -5732,7 +5750,7 @@ nice_agent_generate_local_sdp (NiceAgent *agent)
 
   g_return_val_if_fail (NICE_IS_AGENT (agent), NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   for (i = agent->streams; i; i = i->next) {
     NiceStream *stream = i->data;
@@ -5756,7 +5774,7 @@ nice_agent_generate_local_stream_sdp (NiceAgent *agent, guint stream_id,
   g_return_val_if_fail (NICE_IS_AGENT (agent), NULL);
   g_return_val_if_fail (stream_id >= 1, NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (stream == NULL)
@@ -5781,7 +5799,7 @@ nice_agent_generate_local_candidate_sdp (NiceAgent *agent,
   g_return_val_if_fail (NICE_IS_AGENT (agent), NULL);
   g_return_val_if_fail (candidate != NULL, NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   sdp = g_string_new (NULL);
   _generate_candidate_sdp (agent, candidate, sdp);
@@ -5803,7 +5821,7 @@ nice_agent_parse_remote_sdp (NiceAgent *agent, const gchar *sdp)
   g_return_val_if_fail (NICE_IS_AGENT (agent), -1);
   g_return_val_if_fail (sdp != NULL, -1);
 
-  agent_lock();
+  agent_lock (agent);
 
   for (l = agent->streams; l; l = l->next) {
     NiceStream *stream = l->data;
@@ -5895,7 +5913,7 @@ nice_agent_parse_remote_stream_sdp (NiceAgent *agent, guint stream_id,
   g_return_val_if_fail (stream_id >= 1, NULL);
   g_return_val_if_fail (sdp != NULL, NULL);
 
-  agent_lock();
+  agent_lock (agent);
 
   stream = agent_find_stream (agent, stream_id);
   if (stream == NULL) {
@@ -6074,7 +6092,7 @@ nice_agent_get_io_stream (NiceAgent *agent, guint stream_id,
 
   g_return_val_if_fail (agent->reliable, NULL);
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id, NULL, &component))
     goto done;
@@ -6100,7 +6118,7 @@ nice_agent_forget_relays (NiceAgent *agent, guint stream_id, guint component_id)
   g_return_val_if_fail (stream_id >= 1, FALSE);
   g_return_val_if_fail (component_id >= 1, FALSE);
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, stream_id, component_id, NULL, &component)) {
     ret = FALSE;
@@ -6157,12 +6175,12 @@ nice_agent_get_component_state (NiceAgent *agent,
   NiceComponentState state = NICE_COMPONENT_STATE_FAILED;
   NiceComponent *component;
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (agent_find_component (agent, stream_id, component_id, NULL, &component))
     state = component->state;
 
-  agent_unlock ();
+  agent_unlock (agent);
 
   return state;
 }

--- a/agent/component.c
+++ b/agent/component.c
@@ -880,7 +880,7 @@ nice_component_emit_io_callback (NiceComponent *component,
     agent_unlock_and_emit (agent);
     io_callback (agent, stream_id,
         component_id, buf_len, (gchar *) buf, io_user_data);
-    agent_lock ();
+    agent_lock (agent);
   } else {
     IOCallbackData *data;
 
@@ -1181,7 +1181,7 @@ component_source_prepare (GSource *source, gint *timeout_)
     return FALSE;
 
   /* Needed due to accessing the Component. */
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent,
           component_source->stream_id, component_source->component_id, NULL,

--- a/agent/discovery.c
+++ b/agent/discovery.c
@@ -559,9 +559,9 @@ HostCandidateResult discovery_add_local_host_candidate (
   if (transport == NICE_CANDIDATE_TRANSPORT_UDP) {
     nicesock = nice_udp_bsd_socket_new (address);
   } else if (transport == NICE_CANDIDATE_TRANSPORT_TCP_ACTIVE) {
-    nicesock = nice_tcp_active_socket_new (agent->main_context, address);
+    nicesock = nice_tcp_active_socket_new (agent, agent->main_context, address);
   } else if (transport == NICE_CANDIDATE_TRANSPORT_TCP_PASSIVE) {
-    nicesock = nice_tcp_passive_socket_new (agent->main_context, address);
+    nicesock = nice_tcp_passive_socket_new (agent, agent->main_context, address);
   } else {
     /* TODO: Add TCP-SO */
   }
@@ -736,7 +736,7 @@ discovery_add_relay_candidate (
   candidate->turn = turn_server_ref (turn);
 
   /* step: link to the base candidate+socket */
-  relay_socket = nice_udp_turn_socket_new (agent->main_context, address,
+  relay_socket = nice_udp_turn_socket_new (agent, agent->main_context, address,
       base_socket, &turn->server,
       turn->username, turn->password,
       agent_to_turn_socket_compatibility (agent));
@@ -1187,11 +1187,11 @@ static gboolean priv_discovery_tick (gpointer pointer)
   NiceAgent *agent = pointer;
   gboolean ret;
 
-  agent_lock();
+  agent_lock(agent);
   if (g_source_is_destroyed (g_main_current_source ())) {
     nice_debug ("Source was destroyed. "
         "Avoided race condition in priv_discovery_tick");
-    agent_unlock ();
+    agent_unlock (agent);
     return FALSE;
   }
 

--- a/agent/inputstream.c
+++ b/agent/inputstream.c
@@ -341,7 +341,7 @@ nice_input_stream_close (GInputStream *stream, GCancellable *cancellable,
   if (agent == NULL)
     return TRUE;
 
-  agent_lock ();
+  agent_lock (agent);
 
   /* Shut down the read side of the pseudo-TCP stream, if it still exists. */
   if (agent_find_component (agent, priv->stream_id, priv->component_id,
@@ -350,7 +350,7 @@ nice_input_stream_close (GInputStream *stream, GCancellable *cancellable,
     pseudo_tcp_socket_shutdown (component->tcp, PSEUDO_TCP_SHUTDOWN_RD);
   }
 
-  agent_unlock ();
+  agent_unlock (agent);
 
   g_object_unref (agent);
 
@@ -376,7 +376,7 @@ nice_input_stream_is_readable (GPollableInputStream *stream)
   if (agent == NULL)
     return FALSE;
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, priv->stream_id, priv->component_id,
           &_stream, &component)) {
@@ -405,7 +405,7 @@ nice_input_stream_is_readable (GPollableInputStream *stream)
   }
 
 done:
-  agent_unlock ();
+  agent_unlock (agent);
 
   g_object_unref (agent);
 

--- a/agent/outputstream.c
+++ b/agent/outputstream.c
@@ -485,7 +485,7 @@ nice_output_stream_close (GOutputStream *stream, GCancellable *cancellable,
   if (agent == NULL)
     return TRUE;
 
-  agent_lock ();
+  agent_lock (agent);
 
   /* Shut down the write side of the pseudo-TCP stream. */
   if (agent_find_component (agent, priv->stream_id, priv->component_id,
@@ -494,7 +494,7 @@ nice_output_stream_close (GOutputStream *stream, GCancellable *cancellable,
     pseudo_tcp_socket_shutdown (component->tcp, PSEUDO_TCP_SHUTDOWN_WR);
   }
 
-  agent_unlock ();
+  agent_unlock (agent);
 
   g_object_unref (agent);
 
@@ -519,7 +519,7 @@ nice_output_stream_is_writable (GPollableOutputStream *stream)
   if (agent == NULL)
     return FALSE;
 
-  agent_lock ();
+  agent_lock (agent);
 
   if (!agent_find_component (agent, priv->stream_id, priv->component_id,
           &_stream, &component)) {
@@ -540,7 +540,7 @@ nice_output_stream_is_writable (GPollableOutputStream *stream)
   }
 
 done:
-  agent_unlock ();
+  agent_unlock (agent);
 
   g_object_unref (agent);
 
@@ -618,7 +618,7 @@ nice_output_stream_create_source (GPollableOutputStream *stream,
   if (agent == NULL)
     return component_source;
 
-  agent_lock ();
+  agent_lock (agent);
 
   /* Grab the socket for this component. */
   if (!agent_find_component (agent, priv->stream_id, priv->component_id,
@@ -638,7 +638,7 @@ nice_output_stream_create_source (GPollableOutputStream *stream,
   }
 
 done:
-  agent_unlock ();
+  agent_unlock (agent);
 
   g_object_unref (agent);
 

--- a/socket/tcp-active.c
+++ b/socket/tcp-active.c
@@ -56,6 +56,7 @@
 #define TCP_NODELAY 1
 
 typedef struct {
+  NiceAgent *agent;
   GSocketAddress *local_addr;
   GMainContext *context;
 } TcpActivePriv;
@@ -75,7 +76,8 @@ static void socket_set_writable_callback (NiceSocket *sock,
 
 
 NiceSocket *
-nice_tcp_active_socket_new (GMainContext *ctx, NiceAddress *addr)
+nice_tcp_active_socket_new (NiceAgent *agent, GMainContext *ctx,
+    NiceAddress *addr)
 {
   union {
     struct sockaddr_storage storage;
@@ -112,6 +114,7 @@ nice_tcp_active_socket_new (GMainContext *ctx, NiceAddress *addr)
 
   sock->priv = priv = g_slice_new0 (TcpActivePriv);
 
+  priv->agent = agent;
   priv->context = g_main_context_ref (ctx);
   priv->local_addr = gaddr;
 
@@ -260,8 +263,8 @@ nice_tcp_active_socket_connect (NiceSocket *sock, NiceAddress *addr)
 
   nice_address_set_from_sockaddr (&local_addr, &name.addr);
 
-  new_socket = nice_tcp_bsd_socket_new_from_gsock (priv->context, gsock,
-      &local_addr, addr, TRUE);
+  new_socket = nice_tcp_bsd_socket_new_from_gsock (priv->agent, priv->context,
+      gsock, &local_addr, addr, TRUE);
   g_object_unref (gsock);
 
   return new_socket;

--- a/socket/tcp-active.h
+++ b/socket/tcp-active.h
@@ -41,7 +41,7 @@
 G_BEGIN_DECLS
 
 
-NiceSocket * nice_tcp_active_socket_new (GMainContext *ctx, NiceAddress *addr);
+NiceSocket * nice_tcp_active_socket_new (NiceAgent *agent, GMainContext *ctx, NiceAddress *addr);
 NiceSocket * nice_tcp_active_socket_connect (NiceSocket *socket, NiceAddress *addr);
 
 

--- a/socket/tcp-bsd.h
+++ b/socket/tcp-bsd.h
@@ -42,12 +42,13 @@
 G_BEGIN_DECLS
 
 NiceSocket *
-nice_tcp_bsd_socket_new (GMainContext *ctx, NiceAddress *remote_addr,
-    NiceAddress *local_addr, gboolean reliable);
+nice_tcp_bsd_socket_new (NiceAgent *agent, GMainContext *ctx,
+    NiceAddress *remote_addr, NiceAddress *local_addr, gboolean reliable);
 
 NiceSocket *
-nice_tcp_bsd_socket_new_from_gsock (GMainContext *ctx, GSocket *gsock,
-    NiceAddress *remote_addr, NiceAddress *local_addr, gboolean reliable);
+nice_tcp_bsd_socket_new_from_gsock (NiceAgent *agent, GMainContext *ctx,
+    GSocket *gsock, NiceAddress *remote_addr, NiceAddress *local_addr,
+    gboolean reliable);
 
 G_END_DECLS
 

--- a/socket/tcp-passive.h
+++ b/socket/tcp-passive.h
@@ -43,7 +43,7 @@
 G_BEGIN_DECLS
 
 
-NiceSocket * nice_tcp_passive_socket_new (GMainContext *ctx, NiceAddress *addr);
+NiceSocket * nice_tcp_passive_socket_new (NiceAgent *agent, GMainContext *ctx, NiceAddress *addr);
 NiceSocket * nice_tcp_passive_socket_accept (NiceSocket *socket);
 
 

--- a/socket/udp-turn.h
+++ b/socket/udp-turn.h
@@ -65,7 +65,7 @@ gboolean
 nice_udp_turn_socket_set_peer (NiceSocket *sock, NiceAddress *peer);
 
 NiceSocket *
-nice_udp_turn_socket_new (GMainContext *ctx, NiceAddress *addr,
+nice_udp_turn_socket_new (NiceAgent *agent, GMainContext *ctx, NiceAddress *addr,
     NiceSocket *base_socket, NiceAddress *server_addr,
     gchar *username, gchar *password, NiceTurnSocketCompatibility compatibility);
 

--- a/tests/test-socket-is-based-on.c
+++ b/tests/test-socket-is-based-on.c
@@ -94,9 +94,12 @@ main (int argc, char *argv[])
   /* Standalone socket */
   udp_bsd = nice_udp_bsd_socket_new (&addr);
 
+  NiceAgent *agent = nice_agent_new(
+      g_main_loop_get_context (mainloop), NICE_COMPATIBILITY_RFC5245);
+
   /* tcp_passive -> pseudossl -> udp_turn_over_tcp */
-  tcp_active = nice_tcp_active_socket_new (g_main_loop_get_context (mainloop),
-      &addr);
+  tcp_active = nice_tcp_active_socket_new (agent,
+      g_main_loop_get_context (mainloop), &addr);
   pseudossl = nice_pseudossl_socket_new (tcp_active,
       NICE_PSEUDOSSL_SOCKET_COMPATIBILITY_GOOGLE);
   udp_turn_over_tcp = nice_udp_turn_over_tcp_socket_new (pseudossl,
@@ -116,6 +119,7 @@ main (int argc, char *argv[])
   nice_socket_free (udp_bsd);
   nice_socket_free (udp_turn_over_tcp);
 
+  g_object_unref (agent);
   g_main_loop_unref (mainloop);
 
   return 0;

--- a/tests/test-tcp.c
+++ b/tests/test-tcp.c
@@ -99,8 +99,11 @@ main (void)
 
   nice_address_init (&tmp);
 
-  passive_sock = nice_tcp_passive_socket_new (g_main_loop_get_context (mainloop),
-      &passive_bind_addr);
+  NiceAgent *agent = nice_agent_new(
+      g_main_loop_get_context (mainloop), NICE_COMPATIBILITY_RFC5245);
+
+  passive_sock = nice_tcp_passive_socket_new (agent,
+      g_main_loop_get_context (mainloop), &passive_bind_addr);
   g_assert (passive_sock);
 
   srv_listen_source = g_socket_create_source (passive_sock->fileno,
@@ -149,7 +152,7 @@ main (void)
 
   nice_socket_free (client);
   nice_socket_free (server);
-
+  g_object_unref (agent);
   g_source_unref (srv_listen_source);
   g_source_unref (srv_input_source);
   g_source_unref (cli_input_source);


### PR DESCRIPTION
Lock contention in critical pathes is removed by replacing global agent lock with separate per-agent locks.
It was a performance bottleneck in multi-agent multi-threaded high loaded applications.
See https://phabricator.freedesktop.org/T93
Now agent_lock and agent_unlock functions operate on corresponding NiceAgent.